### PR TITLE
allow passing in context information to assert methods

### DIFF
--- a/lib/Specio/Exception.pm
+++ b/lib/Specio/Exception.pm
@@ -29,6 +29,9 @@ use Specio::OO;
         stack_trace => {
             init_arg => undef,
         },
+        context => {
+            isa      => 'HashRef',
+        },
     };
 
     ## no critic (Subroutines::ProhibitUnusedPrivateSubroutines)
@@ -50,6 +53,12 @@ sub as_string {
     my $self = shift;
 
     my $str = $self->message;
+    if ($self->context and my %context = %{$self->context}) {
+        $str
+          .= ' ('
+          . join(', ', map { "$_: $context{$_}" } sort keys %context)
+          . ')';
+    }
     $str .= "\n\n" . $self->stack_trace->as_string;
 
     return $str;

--- a/t/exception.t
+++ b/t/exception.t
@@ -31,6 +31,16 @@ use Specio::Library::Builtins;
         qr/Validation failed for type named Str .+ with value \[\s*\]/,
         'exception contains expected error'
     );
+
+    $e = exception {
+        $str->validate_or_die( [], { attribute => 'foo' } );
+    };
+
+    like(
+        $e->as_string,
+        qr/Validation failed for type named Str .+ with value \[\s*\] \(attribute: foo\)/,
+        'exception contains expected error'
+    );
 }
 
 done_testing();


### PR DESCRIPTION
This isn't meant to be a finished product, but a starting point for discussion.

What I'd like to be able to do is attach attribute information when doing assertions, and have that information end up in the exception object and stringification.